### PR TITLE
Feat/30/회원가입 폼 이메일, 닉네임 Input 구현 + 에러메시지, 정규표현식 상수화

### DIFF
--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -1,3 +1,5 @@
+import SignUpForm from "@/src/components/signup/SignUpForm";
+
 export default function SingUp() {
-  return <div></div>;
+  return <SignUpForm />;
 }

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -1,4 +1,4 @@
-import SignUpForm from "@/src/components/signup/SignUpForm";
+import SignUpForm from "@/src/components/auth/signUp/SignUpForm";
 
 export default function SingUp() {
   return <SignUpForm />;

--- a/src/components/auth/signUp/SignUpForm.tsx
+++ b/src/components/auth/signUp/SignUpForm.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import {
+  StyledDescription,
+  StyledInput,
+  StyledInputContainer,
+  StyledLabel,
+} from "../../common/input/Styled/StyledInput";
+import ERROR_MESSAGE from "@/src/constant/ERROR_MESSAGE";
+import REGEX from "@/src/constant/REGEX";
+
+type SignUpData = {
+  email: String;
+  nickname: string;
+  password: string;
+  passwordConfirmation: string;
+};
+
+export default function SignUpForm() {
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm<SignUpData>();
+  const onSubmit = (data: SignUpData) => console.log(data);
+  console.log(errors);
+
+  // TODO : email, nickname 중복시 사용할 에러추가 코드 추가 예정
+  // setError("email", { type: "duplicated", message: ERROR_MESSAGE.DUPLICATE_EMAIL });
+  // setError("nickname", { type: "duplicated", message: ERROR_MESSAGE.DUPLICATE_NICKNAME });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <StyledInputContainer>
+        <StyledLabel htmlFor="signUpEmailInput">이메일</StyledLabel>
+        <StyledInput
+          $isError={errors.email ? true : false}
+          type="email"
+          placeholder="이메일을 입력해 주세요"
+          {...register("email", {
+            required: {
+              value: true,
+              message: ERROR_MESSAGE.REQUIRED_EMAIL,
+            },
+            pattern: {
+              value: REGEX.EMAIL,
+              message: ERROR_MESSAGE.REQUIRED_EMAIL_FORMAT,
+            },
+          })}
+          id="signUpEmailInput"
+        />
+        {errors.email && <StyledDescription $isError>{errors.email.message} </StyledDescription>}
+      </StyledInputContainer>
+      <StyledInputContainer>
+        <StyledLabel htmlFor="signUpNickname">닉네임</StyledLabel>
+        <StyledInput
+          $isError={errors.nickname ? true : false}
+          type="nickname"
+          placeholder="닉네임을 입력해 주세요"
+          {...register("nickname", {
+            required: {
+              value: true,
+              message: ERROR_MESSAGE.REQUIRED_NICKNAME,
+            },
+            max: {
+              value: 30,
+              message: ERROR_MESSAGE.NICKNAME_MAX_LENGTH,
+            },
+          })}
+          id="signUpNickname"
+        />
+        {errors.nickname && <StyledDescription $isError>{errors.nickname.message} </StyledDescription>}
+      </StyledInputContainer>
+
+      {/* TODO: 제출 버튼 추가 예정 */}
+      {/* <input type="submit" /> */}
+    </form>
+  );
+}

--- a/src/components/auth/signUp/SignUpForm.tsx
+++ b/src/components/auth/signUp/SignUpForm.tsx
@@ -63,8 +63,8 @@ export default function SignUpForm() {
               value: true,
               message: ERROR_MESSAGE.REQUIRED_NICKNAME,
             },
-            max: {
-              value: 30,
+            maxLength: {
+              value: 20,
               message: ERROR_MESSAGE.NICKNAME_MAX_LENGTH,
             },
           })}
@@ -74,7 +74,7 @@ export default function SignUpForm() {
       </StyledInputContainer>
 
       {/* TODO: 제출 버튼 추가 예정 */}
-      {/* <input type="submit" /> */}
+      <input type="submit" />
     </form>
   );
 }

--- a/src/constant/ERROR_MESSAGE.ts
+++ b/src/constant/ERROR_MESSAGE.ts
@@ -1,0 +1,15 @@
+const ERROR_MESSAGE = {
+  REQUIRED_EMAIL: "이메일은 필수 입력입니다.",
+  REQUIRED_EMAIL_FORMAT: "이메일 형식으로 작성해 주세요.",
+  DUPLICATE_EMAIL: "이미 사용중인 이메일입니다.",
+  REQUIRED_NICKNAME: "닉네임은 필수 입력입니다.",
+  NICKNAME_MAX_LENGTH: "닉네임은 최대 20자까지 가능합니다",
+  DUPLICATE_NICKNAME: "이미 사용중인 닉네임입니다.",
+  REQUIRED_PASSWORD: "비밀번호는 필수 입력입니다.",
+  REQUIRED_PASSWORD_FORMAT: "비밀번호는 숫자, 영문, 특수문자로만 가능합니다.",
+  PASSWORD_MIN_LENGTH: "비밀번호는 최소 8자 이상입니다.",
+  REQUIRED_PW_COMFIRMATION: "비밀번호 확인을 입력해주세요.",
+  NOT_MATCH_PASSWORD: "비밀번호가 일치하지 않습니다.",
+};
+
+export default ERROR_MESSAGE;

--- a/src/constant/REGEX.ts
+++ b/src/constant/REGEX.ts
@@ -1,0 +1,6 @@
+const REGEX = {
+  EMAIL: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/i,
+  PASSWORD: /^[a-zA-Z0-9!@#$%^&*]+$/,
+};
+
+export default REGEX;


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #30 
- 회원가입 페이지 form의 email, nickname input 구현
- 에러메시지, 정규표현식 상수 설정

## 스크린샷, 녹화
- 기본 화면
<img width="265" alt="image" src="https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/aa5e87b4-5e7d-4d86-8586-a1f4cbc46120">

-데이터 입력
<img width="256" alt="image" src="https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/79e069c4-ae4b-4ad1-abdc-1c58627e60a8">
<img width="308" alt="image" src="https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/5321b1e2-c3ed-47ef-9aed-77c8a959fd5e">

-에러 화면
<img width="256" alt="image" src="https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/3ba365e5-a449-48ee-afdb-73fdd38efef2">


## 구체적인 구현 설명

- 입력값에 대하여 다음 사항들을 확인합니다.
    - 이메일 입력창에서 blur 될 때, 아무것도 적혀있지 않다면 다음 에러 메세지를 보여줍니다. “이메일은 필수 입력입니다.”
    - 이메일 입력창에서 blur 될 때, 이메일 형식이 아닐 경우 이메일 입력창에 다음 에러 메세지를 보여줍니다. “이메일 형식으로 작성해 주세요.”
    - 이메일 입력창에서 blur 될 때, 이미 사용중인 이메일인지 확인 후 중복될 경우 다음 에러 메세지를 보여줍니다. “이미 사용중인 이메일입니다.”
    - 닉네임 입력창에서 blur 될 때, 아무것도 적혀있지 않다면 다음 에러 메세지를 보여줍니다. “닉네임은 필수 입력입니다.”
    - 닉네임 입력창에서 blur 될 때, 글자수가 20자를 초과하면 다음 에러 메세지를 보여줍니다. “닉네임은 최대 20자까지 가능합니다.”
    - 닉네임 입력창에서 blur 될 때, 이미 사용중인 닉네임인지 확인 후 중복될 경우 다음 에러 메세지를 보여줍니다. “이미 사용중인 닉네임입니다.”

## 공유사항 (막히는 부분, 고민되는 부분)

- 이메일, 닉네임 중복검사는 차후 api 연결시에 추가할 예정입니다.
