### PR TITLE
Feat : main 페이지/cardList 컴포넌트 구현

### DIFF
--- a/src/apis/apiHome/index.ts
+++ b/src/apis/apiHome/index.ts
@@ -1,0 +1,9 @@
+import { apiCall } from "@/src/lib/axiosInstance";
+import { API_ROUTE } from "@/src/routes";
+
+//상품 전체 조회하는 함수
+export const getProductList = async () => {
+  const requestProps = { method: "get", endPoint: API_ROUTE.PRODUCTS };
+
+  return await apiCall(requestProps);
+};

--- a/src/components/home/BaseCardList/BaseCardList.tsx
+++ b/src/components/home/BaseCardList/BaseCardList.tsx
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+import { getProductList } from "@/src/apis/apiHome";
+import RateTop6CardList from "./RateTop6CardList";
+import ReviewTop6CardList from "./ReviewTop6CardList";
+import * as S from "./Styled/StyledBaseCardList";
+import { Children } from "react";
+
+type CardListBoxWrapPorps = {
+  title: string;
+  description?: string;
+  children: ReactNode;
+};
+
+const CardListBoxWrap = ({ title, description, children }: CardListBoxWrapPorps) => (
+  <S.CardListBoxWrap>
+    <S.CardListTitleBox>
+      <S.CardListTitle>{title}</S.CardListTitle>
+      {description && <S.CardListDes>{description}</S.CardListDes>}
+    </S.CardListTitleBox>
+    <S.CardListBox>{children}</S.CardListBox>
+  </S.CardListBoxWrap>
+);
+
+export default function BaseCardList() {
+  const { data: productList } = useQuery({
+    queryKey: ["productList"],
+    queryFn: () => getProductList(),
+  });
+  if (!productList) {
+    return null;
+  }
+
+  return (
+    <>
+      <CardListBoxWrap title="지금 핫한 상품" description="TOP 6">
+        <ReviewTop6CardList productList={productList} />
+      </CardListBoxWrap>
+      <CardListBoxWrap title="별점이 높은 상품">
+        <RateTop6CardList productList={productList} />
+      </CardListBoxWrap>
+    </>
+  );
+}

--- a/src/components/home/BaseCardList/RateTop6CardList.tsx
+++ b/src/components/home/BaseCardList/RateTop6CardList.tsx
@@ -1,0 +1,33 @@
+import Card from "@/src/components/common/card/Card";
+import { useEffect, useState } from "react";
+import { CardListBox } from "./Styled/StyledBaseCardList";
+import { Item } from "./type";
+
+export default function RateTop6CardList({ productList }: any) {
+  const [rateTop6CardList, setRateTop6CardList] = useState<Item>();
+
+  useEffect(() => {
+    const rateSortedList = productList?.list.sort((a: any, b: any) => b.rating - a.rating);
+    const rateTop6 = rateSortedList?.slice(0, 6);
+    setRateTop6CardList(rateTop6);
+  }, []);
+
+  return (
+    <>
+      {rateTop6CardList?.map((card: any, index: number) => {
+        return (
+          <Card
+            key={index}
+            productId={card.id}
+            imageUrl={card.image}
+            imageAlt={card.name}
+            cardProductTitle={card.name}
+            review={card.reviewCount}
+            pick={card.favoriteCount}
+            rateScore={card.rating}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/home/BaseCardList/ReviewTop6CardList.tsx
+++ b/src/components/home/BaseCardList/ReviewTop6CardList.tsx
@@ -1,0 +1,33 @@
+import Card from "@/src/components/common/card/Card";
+import { useEffect, useState } from "react";
+import { CardListBox } from "./Styled/StyledBaseCardList";
+import { Item } from "./type";
+
+export default function ReviewTop6CardList({ productList }: any) {
+  const [reviewTop6CardList, setReviewTop6CardList] = useState<Item>();
+
+  useEffect(() => {
+    const reviewSortedList = productList?.list.sort((a, b) => b.reviewCount - a.reviewCount);
+    const reviewTop6 = reviewSortedList?.slice(0, 6);
+    setReviewTop6CardList(reviewTop6);
+  }, []);
+
+  return (
+    <>
+      {reviewTop6CardList?.map((card: any, index: number) => {
+        return (
+          <Card
+            key={index}
+            productId={card.id}
+            imageUrl={card.image}
+            imageAlt={card.name}
+            cardProductTitle={card.name}
+            review={card.reviewCount}
+            pick={card.favoriteCount}
+            rateScore={card.rating}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/home/BaseCardList/Styled/StyledBaseCardList.tsx
+++ b/src/components/home/BaseCardList/Styled/StyledBaseCardList.tsx
@@ -1,0 +1,58 @@
+import { fontStyle } from "@/styles/theme";
+import styled from "styled-components";
+
+export const CardListBoxWrap = styled.div`
+  padding: 0 20px;
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.tablet}) {
+    padding: 0 30px;
+  }
+
+  @media (min-width: 1090px) {
+    max-width: 1090px;
+  }
+`;
+
+export const CardListTitleBox = styled.div`
+  display: flex;
+  gap: 10px;
+  margin: 60px 0 30px;
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.tablet}) {
+    gap: 20px;
+    margin: 80px 0 30px;
+  }
+`;
+
+export const CardListTitle = styled.div`
+  color: var(--color-white, #f1f1f5);
+  ${fontStyle({ w: 600, s: 20, l: 28 })};
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.tablet}) {
+    ${fontStyle({ w: 600, s: 24, l: 28 })};
+  }
+`;
+
+export const CardListDes = styled.span`
+  background: var(--main-main_gradation, linear-gradient(91deg, #5097fa 0%, #5363ff 100%));
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  ${fontStyle({ w: 600, s: 20, l: 28 })};
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.tablet}) {
+    ${fontStyle({ w: 600, s: 24, l: 28 })};
+  }
+`;
+
+export const CardListBox = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  gap: 15px;
+
+  @media (min-width: 1090px) {
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(2, 1fr);
+  }
+`;

--- a/src/components/home/BaseCardList/type.ts
+++ b/src/components/home/BaseCardList/type.ts
@@ -1,0 +1,12 @@
+export type Item = {
+  id: number;
+  name: string;
+  image: string;
+  rating: number;
+  reviewCount: number;
+  categoryId: number;
+  createdAt: string;
+  updatedAt: string;
+  writerId: number;
+  favoriteCount: number;
+};


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #28 
- cardList컴포넌트 구현

## 스크린샷, 녹화
### Mobile
![image](https://github.com/5-1-Mogazoa/Mogazoa/assets/84887815/f43c44b8-836b-4d19-a1f4-852f227a159e)

### Tablet
![image](https://github.com/5-1-Mogazoa/Mogazoa/assets/84887815/96275cc4-9095-46d4-ac05-557ac4a231ef)

### PC
![image](https://github.com/5-1-Mogazoa/Mogazoa/assets/84887815/02dbd062-7be0-4920-ae73-b6948a3aabc1)


## 구체적인 구현 설명

검색하지 않았을 때, 
- 지금 핫한 상품 Top 6 : 전체 상품을 리뷰 개수 순으로 정렬하였을 때 상위 6개 상품
- 별점이 높은 상품 : 전체 상품을 별점 순으로 정렬하였을 때 상위 6개 상품
 
보여줍니다.

## 공유사항 (막히는 부분, 고민되는 부분)

- ReviewTop6CardList 컴포넌트 랑 RateTop6CardList 컴포넌트가 구조가 비슷해서 합치고 싶은데, 어떻게 변경해야 할지 모르겠어요..! 
