### PR TITLE
feat: SignUpForm의 비밀번호, 비밀번호 확인, 가입하기 버튼 구현

### DIFF
--- a/src/components/auth/signUp/SignUpForm.tsx
+++ b/src/components/auth/signUp/SignUpForm.tsx
@@ -1,13 +1,54 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import {
   StyledDescription,
   StyledInput,
   StyledInputContainer,
   StyledLabel,
+  StyledPasswordInputContainer,
+  StyledPasswordOnOffButton,
 } from "../../common/input/Styled/StyledInput";
 import ERROR_MESSAGE from "@/src/constant/ERROR_MESSAGE";
 import REGEX from "@/src/constant/REGEX";
+import { StyledPrimaryButton } from "../../common/button/Styled/StyledButton";
+import styled from "styled-components";
+
+const StyledSignUpForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  width: 335px;
+  gap: 30px;
+  padding-top: 30px;
+  margin: 0 auto;
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.tablet}) {
+    padding-top: 180px;
+    width: 440px;
+    gap: 40px;
+  }
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.desktop}) {
+    padding-top: 90px;
+    width: 640px;
+  }
+`;
+
+const StyledSignUpButtonContainer = styled.div`
+  margin-top: 126px;
+  width: 335px;
+  height: 50px;
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.tablet}) {
+    margin-top: 20px;
+    width: 440px;
+    height: 55px;
+  }
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.desktop}) {
+    width: 640px;
+    height: 65px;
+  }
+`;
 
 type SignUpData = {
   email: String;
@@ -22,16 +63,27 @@ export default function SignUpForm() {
     handleSubmit,
     setError,
     formState: { errors },
-  } = useForm<SignUpData>();
-  const onSubmit = (data: SignUpData) => console.log(data);
-  console.log(errors);
+  } = useForm<SignUpData>({ mode: "onBlur" });
+  const onSubmit = (data: SignUpData) => {
+    if (data.password !== data.passwordConfirmation) {
+      setError("passwordConfirmation", { type: "matched", message: ERROR_MESSAGE.NOT_MATCH_PASSWORD });
+      return;
+    }
+    console.log(data);
+  };
+  const hasError = Object.values(errors).length;
+
+  const [isPWView, setIsPWView] = useState(false);
+  const [isPWConfirmationView, setIsPWConfirmationView] = useState(false);
+  const handlePWView = () => setIsPWView(!isPWView);
+  const handlePWConfirmationView = () => setIsPWConfirmationView(!isPWConfirmationView);
 
   // TODO : email, nickname 중복시 사용할 에러추가 코드 추가 예정
   // setError("email", { type: "duplicated", message: ERROR_MESSAGE.DUPLICATE_EMAIL });
   // setError("nickname", { type: "duplicated", message: ERROR_MESSAGE.DUPLICATE_NICKNAME });
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <StyledSignUpForm onSubmit={handleSubmit(onSubmit)}>
       <StyledInputContainer>
         <StyledLabel htmlFor="signUpEmailInput">이메일</StyledLabel>
         <StyledInput
@@ -72,9 +124,58 @@ export default function SignUpForm() {
         />
         {errors.nickname && <StyledDescription $isError>{errors.nickname.message} </StyledDescription>}
       </StyledInputContainer>
-
+      <StyledInputContainer>
+        <StyledLabel htmlFor="signUpPassword">비밀번호</StyledLabel>
+        <StyledPasswordInputContainer>
+          <StyledInput
+            $isError={errors.password ? true : false}
+            type={isPWView ? "text" : "password"}
+            placeholder="비밀번호를 입력해 주세요"
+            {...register("password", {
+              required: {
+                value: true,
+                message: ERROR_MESSAGE.REQUIRED_PASSWORD,
+              },
+              pattern: {
+                value: REGEX.PASSWORD,
+                message: ERROR_MESSAGE.REQUIRED_PASSWORD_FORMAT,
+              },
+              minLength: {
+                value: 8,
+                message: ERROR_MESSAGE.PASSWORD_MIN_LENGTH,
+              },
+            })}
+            id="signUpPassword"
+          />
+          <StyledPasswordOnOffButton onClick={handlePWView} $isVisibility={isPWView} />
+        </StyledPasswordInputContainer>
+        {errors.password && <StyledDescription $isError>{errors.password.message} </StyledDescription>}
+      </StyledInputContainer>
+      <StyledInputContainer>
+        <StyledLabel htmlFor="signUpPasswordConfirmation">비밀번호 확인</StyledLabel>
+        <StyledPasswordInputContainer>
+          <StyledInput
+            $isError={errors.passwordConfirmation ? true : false}
+            type={isPWConfirmationView ? "text" : "password"}
+            placeholder="비밀번호를 한번 더 입력해 주세요"
+            {...register("passwordConfirmation", {
+              required: {
+                value: true,
+                message: ERROR_MESSAGE.REQUIRED_PW_COMFIRMATION,
+              },
+            })}
+            id="signUpPasswordConfirmation"
+          />
+          <StyledPasswordOnOffButton onClick={handlePWConfirmationView} $isVisibility={isPWConfirmationView} />
+        </StyledPasswordInputContainer>
+        {errors.passwordConfirmation && (
+          <StyledDescription $isError>{errors.passwordConfirmation.message} </StyledDescription>
+        )}
+      </StyledInputContainer>
       {/* TODO: 제출 버튼 추가 예정 */}
-      <input type="submit" />
-    </form>
+      <StyledSignUpButtonContainer>
+        <StyledPrimaryButton disabled={hasError ? true : false}>가입하기</StyledPrimaryButton>
+      </StyledSignUpButtonContainer>
+    </StyledSignUpForm>
   );
 }

--- a/src/components/auth/signUp/SignUpForm.tsx
+++ b/src/components/auth/signUp/SignUpForm.tsx
@@ -172,7 +172,6 @@ export default function SignUpForm() {
           <StyledDescription $isError>{errors.passwordConfirmation.message} </StyledDescription>
         )}
       </StyledInputContainer>
-      {/* TODO: 제출 버튼 추가 예정 */}
       <StyledSignUpButtonContainer>
         <StyledPrimaryButton disabled={hasError ? true : false}>가입하기</StyledPrimaryButton>
       </StyledSignUpButtonContainer>

--- a/src/components/common/input/Styled/StyledInput.tsx
+++ b/src/components/common/input/Styled/StyledInput.tsx
@@ -87,8 +87,9 @@ const StyledPasswordInputContainer = styled.div`
   }
 `;
 
-const StyledPasswordOnOffButton = styled.button<StyledInputProps>`
+const StyledPasswordOnOffButton = styled.div<StyledInputProps>`
   position: absolute;
+  cursor: pointer;
   width: 22px;
   height: 22px;
   top: 50%;


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #36 
- SignUpForm의 비밀번호, 비밀번호 확인, 가입하기 버튼 구현

## 스크린샷, 녹화
- 기본 화면 모바일
<img width="278" alt="image" src="https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/8a2bac2d-bbf5-450d-afca-0188e9021dc5">

 - 태블릿
<img width="357" alt="image" src="https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/688abcab-4df7-4fea-aa88-ec3bdd75ce7b">

 - 데스크탑
<img width="521" alt="image" src="https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/bdc3d688-8f4e-4932-b769-17b81d4f98c8">

- 데이터 입력
<img width="272" alt="image" src="https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/e4e373f4-f539-47bc-bb7a-cd3d2aef4683">
<img width="200" alt="image" src="https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/c1e6f5ad-4234-4979-bebe-4ba2c022fe67">

- 에러 발생시
<img width="266" alt="image" src="https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/38da2e1b-ec33-408f-b6b5-b2c19312e097">



## 구체적인 구현 설명
 - 비밀번호 입력창에서 blur 될 때, 아무것도 적혀있지 않다면 다음 에러 메세지를 보여줍니다. “비밀번호는 필수 입력입니다.”
- 비밀번호 입력창에서 blur 될 때, 비밀번호가 8자 미만일 경우 다음 에러 메세지를 보여줍니다. “비밀번호는 최소 8자 이상입니다.”
- 비밀번호 입력창에서 blur 될 때, 숫자,영문,특수문자(!@#$%^&*) 로만 이루어지지 않았을 경우 다음 에러 메세지를 보여줍니다. “비밀번호는 숫자, 영문, 특수문자로만 가능합니다.”
- 비밀번호 확인 입력창에서 blur 될 때, 아무것도 적혀있지 않다면 다음 에러 메세지를 보여줍니다. “비밀번호 확인을 입력해주세요.”
- 비밀번호 확인 입력창에서 blur 될 때, 비밀번호 확인 입력창이 비어있지 않은 상태이며 비밀번호 입력값과 같지 않다면 다음 에러 메세지를 보여줍니다. “비밀번호가 일치하지 않습니다.”

## 공유사항 (막히는 부분, 고민되는 부분)

-
