### PR TITLE
Design/65/간편회원가입form

### DIFF
--- a/pages/oauth/signup/index.tsx
+++ b/pages/oauth/signup/index.tsx
@@ -1,3 +1,5 @@
+import OauthSignUpForm from "@/src/components/auth/oauth/OauthSignUpForm";
+
 export default function OauthSignUp() {
-  return <div></div>;
+  return <OauthSignUpForm />;
 }

--- a/src/components/auth/Styled/StyledAuthForm.tsx
+++ b/src/components/auth/Styled/StyledAuthForm.tsx
@@ -32,6 +32,18 @@ const StyledSignInForm = styled(StyledSignUpForm)`
   }
 `;
 
+const StyledOauthSignUpForm = styled(StyledSignUpForm)`
+  padding-top: 228px;
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.tablet}) {
+    padding-top: 376px;
+  }
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.desktop}) {
+    padding-top: 315px;
+  }
+`;
+
 const StyledSignUpButtonContainer = styled.div`
   margin-top: 126px;
   width: 335px;
@@ -57,4 +69,13 @@ const StyledSignInButtonContainer = styled(StyledSignUpButtonContainer)`
   }
 `;
 
-export { StyledSignUpButtonContainer, StyledSignUpForm, StyledSignInButtonContainer, StyledSignInForm };
+const StyledOauthSignUpButtonContainer = styled(StyledSignInButtonContainer)``;
+
+export {
+  StyledOauthSignUpButtonContainer,
+  StyledOauthSignUpForm,
+  StyledSignUpButtonContainer,
+  StyledSignUpForm,
+  StyledSignInButtonContainer,
+  StyledSignInForm,
+};

--- a/src/components/auth/Styled/StyledAuthForm.tsx
+++ b/src/components/auth/Styled/StyledAuthForm.tsx
@@ -1,3 +1,4 @@
+import { fontStyle } from "@/styles/theme";
 import styled from "styled-components";
 
 const StyledSignUpForm = styled.form`
@@ -71,7 +72,36 @@ const StyledSignInButtonContainer = styled(StyledSignUpButtonContainer)`
 
 const StyledOauthSignUpButtonContainer = styled(StyledSignInButtonContainer)``;
 
+const StyledOauthErrorContainer = styled(StyledSignUpForm)`
+  padding-top: 257px;
+  gap: 80px;
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.tablet}) {
+    padding-top: 385px;
+    gap: 120px;
+  }
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.desktop}) {
+    padding-top: 323px;
+    gap: 140px;
+  }
+`;
+
+const StyledOauthErrorMessage = styled.span`
+  color: var(--color-white-f1, #f1f1f5);
+  text-align: center;
+  font-family: Pretendard;
+  font-style: normal;
+  ${fontStyle({ w: 600, s: 20, l: 28 })};
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.desktop}) {
+    ${fontStyle({ w: 600, s: 24, l: 28 })};
+  }
+`;
+
 export {
+  StyledOauthErrorContainer,
+  StyledOauthErrorMessage,
   StyledOauthSignUpButtonContainer,
   StyledOauthSignUpForm,
   StyledSignUpButtonContainer,

--- a/src/components/auth/oauth/OauthError.tsx
+++ b/src/components/auth/oauth/OauthError.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+import { StyledPrimaryButton } from "../../common/button/Styled/StyledButton";
+import { StyledOauthErrorContainer, StyledOauthErrorMessage } from "../Styled/StyledAuthForm";
+
+export default function OauthError() {
+  return (
+    <StyledOauthErrorContainer>
+      <StyledOauthErrorMessage>비정상적인 접근입니다.</StyledOauthErrorMessage>
+      <Link href="/">
+        <StyledPrimaryButton type="button">홈으로 가기</StyledPrimaryButton>
+      </Link>
+    </StyledOauthErrorContainer>
+  );
+}

--- a/src/components/auth/oauth/OauthSignUpForm.tsx
+++ b/src/components/auth/oauth/OauthSignUpForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import {
   StyledDescription,
@@ -11,8 +11,10 @@ import { StyledPrimaryButton } from "../../common/button/Styled/StyledButton";
 import { StyledOauthSignUpButtonContainer, StyledOauthSignUpForm } from "../Styled/StyledAuthForm";
 import PLACEHODLER_MESSAGE from "@/src/constant/PLACEHOLDER_MESSAGE";
 import { OauthDataType } from "@/src/types/oauth/oauthDataType";
+import OauthError from "./OauthError";
 
 export default function OauthSignUpForm() {
+  const [isErrorTest, setIsErrorTest] = useState(false); //임시 에러 설정
   const {
     register,
     handleSubmit,
@@ -27,7 +29,9 @@ export default function OauthSignUpForm() {
 
   const hasError = Object.values(errors).length;
 
-  return (
+  return isErrorTest ? (
+    <OauthError />
+  ) : (
     <StyledOauthSignUpForm onSubmit={handleSubmit(onSubmit)}>
       <StyledInputContainer>
         <StyledLabel htmlFor="signUpNickname">닉네임</StyledLabel>

--- a/src/components/auth/oauth/OauthSignUpForm.tsx
+++ b/src/components/auth/oauth/OauthSignUpForm.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import {
+  StyledDescription,
+  StyledInput,
+  StyledInputContainer,
+  StyledLabel,
+} from "../../common/input/Styled/StyledInput";
+import ERROR_MESSAGE from "@/src/constant/ERROR_MESSAGE";
+import { StyledPrimaryButton } from "../../common/button/Styled/StyledButton";
+import { StyledOauthSignUpButtonContainer, StyledOauthSignUpForm } from "../Styled/StyledAuthForm";
+import PLACEHODLER_MESSAGE from "@/src/constant/PLACEHOLDER_MESSAGE";
+import { OauthDataType } from "@/src/types/oauth/oauthDataType";
+
+export default function OauthSignUpForm() {
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+  } = useForm<OauthDataType>({ mode: "onBlur" });
+
+  const onSubmit = async (data: any) => {
+    //TODO :api 통신 및 닉네임 중복검사 추가 예정
+    setError("nickname", { type: "duplicated", message: ERROR_MESSAGE.DUPLICATE_NICKNAME });
+  };
+
+  const hasError = Object.values(errors).length;
+
+  return (
+    <StyledOauthSignUpForm onSubmit={handleSubmit(onSubmit)}>
+      <StyledInputContainer>
+        <StyledLabel htmlFor="signUpNickname">닉네임</StyledLabel>
+        <StyledInput
+          $isError={errors.nickname ? true : false}
+          type="nickname"
+          placeholder={PLACEHODLER_MESSAGE.REQUIRED_NICKNAME}
+          {...register("nickname", {
+            required: {
+              value: true,
+              message: ERROR_MESSAGE.REQUIRED_NICKNAME,
+            },
+            maxLength: {
+              value: 20,
+              message: ERROR_MESSAGE.NICKNAME_MAX_LENGTH,
+            },
+          })}
+          id="signUpNickname"
+        />
+        {errors.nickname ? (
+          <StyledDescription $isError>{errors.nickname.message} </StyledDescription>
+        ) : (
+          <StyledDescription>최대 20자 가능</StyledDescription>
+        )}
+      </StyledInputContainer>
+      <StyledOauthSignUpButtonContainer>
+        <StyledPrimaryButton disabled={hasError ? true : false}>가입하기</StyledPrimaryButton>
+      </StyledOauthSignUpButtonContainer>
+    </StyledOauthSignUpForm>
+  );
+}

--- a/src/types/oauth/oauthDataType.ts
+++ b/src/types/oauth/oauthDataType.ts
@@ -1,0 +1,3 @@
+export type OauthDataType = {
+  nickname: string;
+};

--- a/src/types/oauth/oauthDataType.ts
+++ b/src/types/oauth/oauthDataType.ts
@@ -1,3 +1,5 @@
 export type OauthDataType = {
   nickname: string;
+  redirectUri: string;
+  token: string;
 };


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #65 
- 간편회원가입(/oauth/signup 페이지) 디자인 구현

## 스크린샷, 녹화
- 간편회원가입 디자인
<img width="303" alt="image" src="https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/8550880a-0506-42bc-9f34-3f4b7eefd722">

-간편회원가입 에러 발생 시
![간편에러](https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/3bb3ad0b-c49a-484c-97db-2df9a147ed20)


## 구체적인 구현 설명

- 간편회원가입 디자인구현입니다.
- 간편회원가입 에러 발생시, 홈으로 가기 버튼을 누르면 홈으로 이동합니다.

## 공유사항 (막히는 부분, 고민되는 부분)

-
