### PR TITLE
Fix: SortDropdown의 재활용성을 위해 정렬기준 map 수정

### DIFF
--- a/src/components/common/button/SortDropdown.tsx
+++ b/src/components/common/button/SortDropdown.tsx
@@ -1,16 +1,18 @@
 import { useState } from "react";
 import * as S from "./Styled/StyledSortDropdown";
 import { OrderOptionType, OrderType } from "@/pages/products/[productId]";
-import { REVIEW_ORDER } from "@/src/constant/DROPDOWN_BUTTON";
+import { PRODUCT_ORDER, REVIEW_ORDER } from "@/src/constant/DROPDOWN_BUTTON";
 
 type SortDropProps = {
+  type: "home" | "products";
   selectedItem: OrderType;
   handleOrderButtonClick: (selectedOrder: OrderType) => void;
 };
 
-export default function SortDropDown({ selectedItem, handleOrderButtonClick }: SortDropProps) {
+export default function SortDropDown({ type, selectedItem, handleOrderButtonClick }: SortDropProps) {
   const [isDropBoxOpen, setIsDropBoxOpen] = useState(false);
   const toggleDropdown = () => setIsDropBoxOpen((prev) => !prev);
+  const orderList = type === "home" ? PRODUCT_ORDER : REVIEW_ORDER;
 
   const handleDropBoxBlur = () => {
     setTimeout(() => {
@@ -30,7 +32,7 @@ export default function SortDropDown({ selectedItem, handleOrderButtonClick }: S
         <S.StyledSortDropdownIcon $isOpen={isDropBoxOpen} />
       </S.StyledSortDropdownButton>
       <S.StyledSortDropdownContent $isOpen={isDropBoxOpen}>
-        {REVIEW_ORDER.map((orderItem) => (
+        {orderList.map((orderItem) => (
           <S.StyledSortDropdownItemWrap key={orderItem.id}>
             <S.StyledSortDropdownItem
               value={orderItem.id as OrderOptionType}

--- a/src/components/product/ReviewList/index.tsx
+++ b/src/components/product/ReviewList/index.tsx
@@ -16,7 +16,7 @@ function ReviewList({ reviewList, order, handleOrderButtonClick }: ReviewListPro
     <S.Container>
       <S.TitleWithOrer>
         상품 리뷰
-        <SortDropdown selectedItem={order} handleOrderButtonClick={handleOrderButtonClick} />
+        <SortDropdown type="products" selectedItem={order} handleOrderButtonClick={handleOrderButtonClick} />
       </S.TitleWithOrer>
       <S.List>
         {reviewList.map((review) => (


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #78 
- 간단한 설명
 **<홈화면과의 코드 충돌 부분에 대한 수정내용>**
1.  공통적으로 사용되는 SORT를 constant > DROPDOWN_BUTTON.ts에 분리
2. SORT와 id 값을 swagger와 동일한 단어로 변경
       SORT -> ORDER
       TIME -> RECENT .. 등
3. 홈화면과 products페이지의 정렬기준 옵션이 다른 것 반영 등
4. 스타일 등 나머지는 은영님 코드 그대로 사용

**<홈화면에서 사용할때 방법>**
![스크린샷 2024-03-08 오전 10 35 24](https://github.com/5-1-Mogazoa/Mogazoa/assets/131663155/59111de3-8966-47a0-970c-707354dfa51b)
![스크린샷 2024-03-08 오전 10 35 49](https://github.com/5-1-Mogazoa/Mogazoa/assets/131663155/f9f9cb3e-69a2-4ed8-834e-76d742ca4046)
`<SortDropdown type="home" selectedItem={order} handleOrderButtonClick={handleOrderButtonClick} />`

## 스크린샷, 녹화

스크린샷은 기본, 녹화는 자유
_변경사항을 테스트하는 방법, 테스트에 사용된 기기 및 브라우저, UI 변경에 대한 관련 이미지 등에 대한 지침을 이곳에 기재해 주세요._
<img width="151" alt="스크린샷 2024-03-08 오전 11 12 34" src="https://github.com/5-1-Mogazoa/Mogazoa/assets/131663155/1daed511-5717-4562-acce-ae11d512ec2c">


## 구체적인 구현 설명

- 구체적인 동작 방법 설명

## 공유사항 (막히는 부분, 고민되는 부분)

