### PR TITLE
feat: accessToken HttpOnly Cookie 설정을 위한 BFF 구현

### DIFF
--- a/pages/api/getToken.ts
+++ b/pages/api/getToken.ts
@@ -1,0 +1,6 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const accessToken = req.cookies.accessToken;
+  res.status(200).json({ accessToken });
+}

--- a/pages/api/resetToken.ts
+++ b/pages/api/resetToken.ts
@@ -1,0 +1,6 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.setHeader("Set-Cookie", `accessToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; Path=/; HttpOnly`);
+  res.status(200).send("쿠키 리셋");
+}

--- a/pages/api/setToken.ts
+++ b/pages/api/setToken.ts
@@ -1,0 +1,13 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { accessToken } = req.body;
+  const expirationDate = new Date();
+  expirationDate.setHours(expirationDate.getHours() + 1);
+
+  res.setHeader(
+    "Set-Cookie",
+    `accessToken=${accessToken}; expires=${expirationDate.toUTCString()}; Path=/; HttpOnly; Secure; SameSite=Strict`,
+  );
+  res.status(200).json({ accessToken });
+}

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -1,6 +1,7 @@
 import { apiCall } from "@/src/lib/axiosInstance";
 import { API_ROUTE } from "@/src/routes";
 import { AuthDataType } from "@/src/types/auth/authDataType";
+import axios from "axios";
 
 export const postSignUpData = async (data: AuthDataType) => {
   const requestProps = {
@@ -20,4 +21,32 @@ export const postSignInData = async (data: AuthDataType) => {
   };
 
   return await apiCall(requestProps);
+};
+
+export const postToken = async (token: string) => {
+  try {
+    const res = await axios.post(API_ROUTE.API_SETTOKEN, { accessToken: token });
+    const result = res.data.accessToken;
+    return result;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const getToken = async () => {
+  try {
+    const res = await axios.get(API_ROUTE.API_GETTOKEN);
+    const result = res.data.accessToken;
+    return result;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const resetToken = async () => {
+  try {
+    await axios.post(API_ROUTE.API_RESETTOKEN);
+  } catch (error) {
+    console.error(error);
+  }
 };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -39,6 +39,10 @@ export const API_ROUTE = {
   AUTH_SIGNIN: "/auth/signIn",
   OAUTH_SIGNUP: (provider: string) => `/auth/signUp/${provider}`,
   OAUTH_SIGNIN: (provider: string) => `/auth/signIn/${provider}`,
+
+  API_SETTOKEN: "/api/setToken",
+  API_GETTOKEN: "/api/getToken",
+  API_RESETTOKEN: "/api/resetToken",
 };
 
 export const QUERY_KEY = {


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #93 
- accessToken HttpOnly Cookie 설정을 위한 BFF 구현

## 스크린샷, 녹화
- 테스트 화면
![쿠키](https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/878e48a4-8308-45e4-b971-845b8fb1a97f)


## 구체적인 구현 설명

- accessToken의 여부를 확인하기 위해서는 async함수 안에서 await getToken() 사용하시면 됩니다.
- 로그아웃에서 사용될 resetToken()은 response 받을게 없어서 바로 사용해도 될 것 같습니다.
- userId는 그대로 localStorage에 저장하도록 하겠습니다.

## 공유사항 (막히는 부분, 고민되는 부분)

-
