### PR TITLE
fix : 전체상품 중에 지금 핫한 상품, 별점 높은 상품 조회 로직변경

### DIFF
--- a/src/components/home/BaseCardList/BaseCardList.tsx
+++ b/src/components/home/BaseCardList/BaseCardList.tsx
@@ -23,21 +23,27 @@ const CardListBoxWrap = ({ title, description, children }: CardListBoxWrapPorps)
 );
 
 export default function BaseCardList() {
-  const { data: products } = useQuery({
-    queryKey: [QUERY_KEY.PRODUCTS],
-    queryFn: () => getProducts({}),
+  const { data: reviewProducts } = useQuery({
+    queryKey: [QUERY_KEY.PRODUCTS, { order: "reviewCount" }],
+    queryFn: () => getProducts({ order: "reviewCount" }),
   });
 
-  if (!products) {
+  const { data: rateProducts } = useQuery({
+    queryKey: [QUERY_KEY.PRODUCTS, { order: "rating" }],
+    queryFn: () => getProducts({ order: "rating" }),
+  });
+
+  if (!reviewProducts || !rateProducts) {
     return null;
   }
+
   return (
     <>
       <CardListBoxWrap title="지금 핫한 상품" description="TOP 6">
-        <ReviewTop6CardList productList={products} />
+        <ReviewTop6CardList productList={reviewProducts} />
       </CardListBoxWrap>
       <CardListBoxWrap title="별점이 높은 상품">
-        <RateTop6CardList productList={products} />
+        <RateTop6CardList productList={rateProducts} />
       </CardListBoxWrap>
     </>
   );

--- a/src/components/home/BaseCardList/RateTop6CardList.tsx
+++ b/src/components/home/BaseCardList/RateTop6CardList.tsx
@@ -7,8 +7,7 @@ export default function RateTop6CardList({ productList }: any) {
   const [rateTop6CardList, setRateTop6CardList] = useState<Item>();
 
   useEffect(() => {
-    const rateSortedList = productList?.list.sort((a: any, b: any) => b.rating - a.rating);
-    const rateTop6 = rateSortedList?.slice(0, 6);
+    const rateTop6 = productList?.list.slice(0, 6);
     setRateTop6CardList(rateTop6);
   }, []);
 

--- a/src/components/home/BaseCardList/ReviewTop6CardList.tsx
+++ b/src/components/home/BaseCardList/ReviewTop6CardList.tsx
@@ -7,8 +7,7 @@ export default function ReviewTop6CardList({ productList }: any) {
   const [reviewTop6CardList, setReviewTop6CardList] = useState<Item>();
 
   useEffect(() => {
-    const reviewSortedList = productList?.list.sort((a, b) => b.reviewCount - a.reviewCount);
-    const reviewTop6 = reviewSortedList?.slice(0, 6);
+    const reviewTop6 = productList?.list.slice(0, 6);
     setReviewTop6CardList(reviewTop6);
   }, []);
 


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #125 
- 지금 핫한 상품, 별점 높은 상품 전체상품 중에서 조회하도록 로직변경

## 스크린샷, 녹화

![image](https://github.com/5-1-Mogazoa/Mogazoa/assets/84887815/b3322805-fe14-4de5-8d03-b50a3b7adba4)
![image](https://github.com/5-1-Mogazoa/Mogazoa/assets/84887815/269bafed-8d0c-4618-850e-4cd1567f408d)


## 구체적인 구현 설명

- 모든 상품 중에서, 지금 핫한 상품은 리뷰가 많은 6개 상품, 
별점이 높은 상품은 별점이 높은 6개 상품이 노출됩니다.

## 공유사항 (막히는 부분, 고민되는 부분)

-
