### PR TITLE
Feat/144/랭커, 리뷰어 클릭 시 프로필 페이지로 이동

### DIFF
--- a/src/components/common/menu/Styled/StyledRankingListItem.tsx
+++ b/src/components/common/menu/Styled/StyledRankingListItem.tsx
@@ -14,7 +14,8 @@ const StyledRankingListItemImage = styled.div<StyledRankingListProps>`
   width: 36px;
   height: 36px;
   border-radius: 100px;
-  background: url(${({ $imageURL }) => $imageURL}) no-repeat center / cover;
+  background: url(${({ $imageURL }) => ($imageURL ? $imageURL : `${location.origin}/icons/default_profile.svg`)})
+    no-repeat center / cover;
 
   @media (min-width: ${({ theme }) => theme.deviceSizes.desktop}) {
     width: 42px;

--- a/src/components/home/Ranking/Ranking.tsx
+++ b/src/components/home/Ranking/Ranking.tsx
@@ -1,7 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import RankingListItem from "../../common/menu/RankingListItem";
 import { getUserRank, getUserReviewed, getUserData } from "@/src/apis/user";
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
+import Link from "next/link";
+import { PAGE_ROUTES } from "@/src/routes";
 
 export default function Ranking() {
   const { data: userRank } = useQuery({
@@ -51,15 +53,16 @@ export default function Ranking() {
     <>
       {userDetails?.map((user: any, index: number) => {
         return (
-          <RankingListItem
-            key={index}
-            userImage={user.image}
-            rankNum={String(index + 1)}
-            ranking={index + 1}
-            reviewerName={user.nickname}
-            Followers={user.followers.followersCount}
-            Reviewer={user.allReviews.length}
-          />
+          <Link key={index} href={PAGE_ROUTES.USER_DETAIL(user.id)}>
+            <RankingListItem
+              userImage={user.image}
+              rankNum={String(index + 1)}
+              ranking={index + 1}
+              reviewerName={user.nickname}
+              Followers={user.followers.followersCount}
+              Reviewer={user.allReviews.length}
+            />
+          </Link>
         );
       })}
     </>

--- a/src/components/product/ReviewItem/index.tsx
+++ b/src/components/product/ReviewItem/index.tsx
@@ -8,6 +8,8 @@ import { useQuery } from "@tanstack/react-query";
 import { ReviewListType } from "@/src/apis/product/schema";
 import { getUserFollowersResponseType, getUserReviewedResponseType } from "@/src/apis/user/schema";
 import { OrderType } from "../ReviewList";
+import Link from "next/link";
+import { PAGE_ROUTES } from "@/src/routes";
 
 type ReviewItemProps = {
   review: ReviewListType;
@@ -51,7 +53,9 @@ function ReviewItem({ review, order, loginToggle }: ReviewItemProps) {
 
   return (
     <S.Container>
-      <ReviewItemUser user={user} userCount={userCount} rating={rating} />
+      <Link href={PAGE_ROUTES.USER_DETAIL(writerId)}>
+        <ReviewItemUser user={user} userCount={userCount} rating={rating} />
+      </Link>
       <S.ContentsWithFooter>
         <ReviewContents content={content} reviewImages={reviewImages} />
         <ReviewFooter


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #144 
- 랭커, 리뷰어 클릭 시 프로필 페이지로 이동

## 스크린샷, 녹화
- 랭킹
![랭킹 클릭](https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/d35afbd4-21b5-4015-af1f-bad1e9c678b9)


- 리뷰어
![리뷰어 클릭](https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/f3a90efc-5a46-42c2-b0d8-94667c33c688)


## 구체적인 구현 설명

- 랭커, 리뷰어 클릭 시 프로필 페이지로 이동
- 랭커 프로필 기본이미지 추가

## 공유사항 (막히는 부분, 고민되는 부분)

-
