### PR TITLE
Feat : 상품 리뷰 생성, 수정 모달의 이미지수, 글자수 제한 추가

### DIFF
--- a/src/apis/product/schema.ts
+++ b/src/apis/product/schema.ts
@@ -29,7 +29,7 @@ export type CategoryType =
   | "식당"
   | "전자기기"
   | "화장품"
-  | "의류/악세서리"
+  | "의류/잡화"
   | "앱";
 
 export interface CategoryMetricType {

--- a/src/components/common/chip/Styled/StyledCategoryChip.tsx
+++ b/src/components/common/chip/Styled/StyledCategoryChip.tsx
@@ -40,7 +40,7 @@ export const StyledCategoryChip = styled.div<StyledCategoryChipProps>`
         return "rgba(35, 181, 129, 0.10)";
       case "화장품":
         return "rgba(253, 82, 154, 0.10)";
-      case "의류/악세서리":
+      case "의류/잡화":
         return "rgba(117, 122, 255, 0.10)";
       case "앱":
         return "rgba(48, 152, 227, 0.10)";
@@ -65,7 +65,7 @@ export const StyledCategoryChip = styled.div<StyledCategoryChipProps>`
         return "#23B581";
       case "화장품":
         return "#FD529A";
-      case "의류/악세서리":
+      case "의류/잡화":
         return "#757AFF";
       case "앱":
         return "#3098E3";

--- a/src/components/common/input/FormMultiImageInput/index.tsx
+++ b/src/components/common/input/FormMultiImageInput/index.tsx
@@ -12,6 +12,7 @@ interface FormMultiImageInputProps {
 function FormMultiImageInput({ name, defaultValue }: FormMultiImageInputProps) {
   const [newValue, setNewValue] = useState<any>([]);
   const [previewImages, setPreviewImages] = useState<string[]>([]);
+  const threeOrLess = previewImages.length < 3;
 
   const {
     control,
@@ -66,28 +67,30 @@ function FormMultiImageInput({ name, defaultValue }: FormMultiImageInputProps) {
   return (
     <S.Container>
       <S.LabelWithPreviews>
-        <S.Label htmlFor={name}>
-          <Controller
-            name={name}
-            control={control}
-            render={({ field: { value, onChange, ...field } }) => (
-              <S.ImageInput
-                id={name}
-                type="file"
-                accept="image/*"
-                multiple
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                  handleFileChange(event);
-                }}
-                {...field}
-              />
-            )}
-          />
-          <S.Icon />
-        </S.Label>
+        {threeOrLess && (
+          <S.Label htmlFor={name}>
+            <Controller
+              name={name}
+              control={control}
+              render={({ field: { value, onChange, ...field } }) => (
+                <S.ImageInput
+                  id={name}
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                    handleFileChange(event);
+                  }}
+                  {...field}
+                />
+              )}
+            />
+            <S.Icon />
+          </S.Label>
+        )}
         {previewImages.map((imageUrl, index) => (
           <S.PreviewImage key={index}>
-            <Image fill src={imageUrl} alt={imageUrl} />
+            <Image fill src={imageUrl} alt={imageUrl} style={{ objectFit: "cover" }} />
             <S.DeleteButton onClick={() => handleDeleteImage(index)} />
           </S.PreviewImage>
         ))}

--- a/src/components/common/input/FormTextareaInput/index.tsx
+++ b/src/components/common/input/FormTextareaInput/index.tsx
@@ -1,6 +1,7 @@
 import { Controller, RegisterOptions, useFormContext } from "react-hook-form";
 import { StyledTextBox } from "../Styled/StyledTextBox";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
+import * as S from "./styled";
 
 export interface FormTextareaInputProps {
   key?: number;
@@ -12,34 +13,47 @@ export interface FormTextareaInputProps {
 
 function FormTextareaInput({ key, name, rules, placeholder, defaultValue }: FormTextareaInputProps) {
   const [newValue, setNewValue] = useState(defaultValue);
+  const [characterCount, setCharactterCount] = useState(defaultValue ? defaultValue.length : 0);
 
   const {
     control,
     formState: { errors },
   } = useFormContext();
 
+  const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const inputValue = event.target.value;
+    // 300자까지만 입력 가능
+    if (inputValue.length <= 300) {
+      setNewValue(inputValue);
+      setCharactterCount(inputValue.length);
+    }
+  };
+
   useEffect(() => {
     setNewValue(defaultValue);
   }, [defaultValue]);
 
   return (
-    <Controller
-      key={key}
-      name={name}
-      control={control}
-      rules={rules}
-      defaultValue={defaultValue || ""}
-      render={({ field }) => (
-        <StyledTextBox
-          value={newValue}
-          onChange={(event) => {
-            field.onChange(event);
-            setNewValue(event.target.value);
-          }}
-          placeholder={placeholder}
-        />
-      )}
-    />
+    <S.Container>
+      <Controller
+        key={key}
+        name={name}
+        control={control}
+        rules={rules}
+        defaultValue={defaultValue || ""}
+        render={({ field }) => (
+          <StyledTextBox
+            value={newValue}
+            onChange={(event) => {
+              handleInputChange(event);
+              field.onChange(event);
+            }}
+            placeholder={placeholder}
+          />
+        )}
+      />
+      <S.Counter>{characterCount} / 300</S.Counter>
+    </S.Container>
   );
 }
 

--- a/src/components/common/input/FormTextareaInput/styled.tsx
+++ b/src/components/common/input/FormTextareaInput/styled.tsx
@@ -1,0 +1,16 @@
+import { fontStyle } from "@/styles/theme";
+import styled from "styled-components";
+
+export const Container = styled.div`
+  position: relative;
+`;
+
+export const Counter = styled.div`
+  position: absolute;
+  bottom: 2rem;
+  right: 2rem;
+  display: flex;
+  gap: 0.8rem;
+  ${fontStyle({ w: 400, s: 14, l: 16.7 })};
+  color: var(--color-gray-6e);
+`;

--- a/src/components/product/ModalEditReview/index.tsx
+++ b/src/components/product/ModalEditReview/index.tsx
@@ -104,12 +104,12 @@ function ModalEditReview({ name, category, order, defaultValue, onClose }: Modal
                 message: ERROR_MESSAGE.REQUIRED_REVIEW,
               },
               maxLength: {
-                value: 500,
+                value: 300,
                 message: ERROR_MESSAGE.REVIEW_MAX_LENGTH,
               },
             }}
             defaultValue={defaultContent}
-            placeholder="리뷰를 작성해 주세요."
+            placeholder="리뷰는 최소 10자 이상 작성해 주세요."
           />
 
           <FormMultiImageInput name="images" defaultValue={defaultImages} />

--- a/src/components/product/ModalEditReview/index.tsx
+++ b/src/components/product/ModalEditReview/index.tsx
@@ -59,7 +59,7 @@ function ModalEditReview({ name, category, order, defaultValue, onClose }: Modal
       for (const file of data.images) {
         // File(새로 추가된 이미지)은 업로드해 새로운 URL 받아서 getImageUrlPromises에 모으기
         if (file instanceof File) {
-          let newImageUrl = await postImage(file);
+          const newImageUrl: Promise<ImageUrlType> = postImage(file) as Promise<ImageUrlType>;
           getImageUrlPromises.push(newImageUrl);
         } else {
           // {id: number} 기존 이미지는 formData.images에 바로 추가하기

--- a/src/components/product/ModalReview/index.tsx
+++ b/src/components/product/ModalReview/index.tsx
@@ -93,12 +93,12 @@ function ModalReview({ productId, name, category, order, defaultValue, onClose }
                 message: ERROR_MESSAGE.REVIEW_MIN_LENGTH,
               },
               maxLength: {
-                value: 500,
+                value: 300,
                 message: ERROR_MESSAGE.REVIEW_MAX_LENGTH,
               },
             }}
             defaultValue={defaultContent}
-            placeholder="리뷰를 작성해 주세요."
+            placeholder="리뷰는 최소 10자 이상 작성해 주세요."
           />
           <FormMultiImageInput name="images" defaultValue={defaultImages} />
         </S.Container>

--- a/src/components/product/ModalReview/index.tsx
+++ b/src/components/product/ModalReview/index.tsx
@@ -53,7 +53,7 @@ function ModalReview({ productId, name, category, order, defaultValue, onClose }
 
     if (data.images !== undefined) {
       for (const file of data.images) {
-        let newImageUrl = await postImage(file);
+        const newImageUrl: Promise<ImageUrlType> = postImage(file) as Promise<ImageUrlType>;
         getImageUrlPromises.push(newImageUrl);
       }
 

--- a/src/components/product/ProductDetail/ProductText/index.tsx
+++ b/src/components/product/ProductDetail/ProductText/index.tsx
@@ -6,7 +6,6 @@ import { CategoryType } from "@/src/apis/product/schema";
 import { deleteFavorite, postFavorite } from "@/src/apis/product";
 import { useQueryClient } from "@tanstack/react-query";
 import { QUERY_KEY } from "@/src/routes";
-import ModalLogin from "../../MadalLogin";
 import { getToken } from "@/src/apis/auth";
 
 type ProductTextProps = {

--- a/src/components/product/RatingStar/index.tsx
+++ b/src/components/product/RatingStar/index.tsx
@@ -41,9 +41,14 @@ export function FormRatingStars({ type, defaultValue }: FormRatingStarsProps) {
             key={ratingValue}
             name="rating"
             control={control}
+            rules={{ min: 1 }}
             defaultValue={defaultValue}
             render={({ field }) => (
-              <button {...field} type="button" onClick={() => field.onChange(ratingValue)}>
+              <button
+                {...field}
+                type="button"
+                onClick={() => field.onChange(ratingValue)}
+                disabled={ratingValue <= 1 && field.value === 1}>
                 <S.Star $type={type} $selected={field.value >= ratingValue ? true : false} $rightStar={rightStar} />
               </button>
             )}

--- a/src/components/product/ReviewList/index.tsx
+++ b/src/components/product/ReviewList/index.tsx
@@ -71,7 +71,7 @@ function ReviewList({ productId, order, setOrder, loginToggle }: ReviewListProps
           </React.Fragment>
         ))}
         <S.ScrollButton ref={ref} onClick={() => fetchNextPage()} disabled={!hasNextPage || isFetchingNextPage}>
-          {!hasNextPage && "리뷰를 다 봤어요!"}
+          {!hasNextPage && !noList && "리뷰를 다 봤어요!"}
         </S.ScrollButton>
       </S.List>
     </S.Container>


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #140 
- 상품 리뷰 생성, 수정 모달의 이미지수, 글자수 제한 추가
   - 리뷰 내용은 300자가 최대이며 입력창에서 현재 글자수와 최대 글자수를 확인할 수 있습니다. 최대 글자수를 초과하는 경우 더이상 입력이 되지 않습니다.
   - 리뷰 내용이 입력창에서 blur 될 때, 아무것도 적혀있지 않다면 다음 에러 메세지를 보여줍니다. “리뷰 내용을 입력해주세요.” , 리뷰 내용이 입력창에서 blur 될 때, 글자수가 10자 미만이라면 다음 에러 메세지를 보여줍니다. “최소 10자 이상 적어주세요.”, 
   => placeholder 문구로 대체(팀미팅때 의논 결과)
   - 이미지가 3개 추가된 상태인 경우 이미지를 추가할 수 있는 버튼은 사라집니다.

## 스크린샷, 녹화

스크린샷은 기본, 녹화는 자유
_변경사항을 테스트하는 방법, 테스트에 사용된 기기 및 브라우저, UI 변경에 대한 관련 이미지 등에 대한 지침을 이곳에 기재해 주세요._


https://github.com/5-1-Mogazoa/Mogazoa/assets/131663155/8895a90c-ff2d-410d-9c5e-3cc007d7fd48




## 구체적인 구현 설명

- 구체적인 동작 방법 설명

## 공유사항 (막히는 부분, 고민되는 부분)

-
