### PR TITLE
feat: 비교하기 버튼 모달 구현

### DIFF
--- a/src/components/product/CompareModal/CompareModal.tsx
+++ b/src/components/product/CompareModal/CompareModal.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import * as S from "@/src/components/common/modal/StyledModal";
+import Image from "next/image";
+import styled from "styled-components";
+import { fontStyle } from "@/styles/theme";
+import { PAGE_ROUTES } from "@/src/routes";
+import Link from "next/link";
+
+interface ModalProps {
+  setIsOpen: (value: boolean) => void;
+  productName: string;
+  productId: number;
+  compareType: CompareModalType;
+}
+
+type CompareModalType = "first" | "second" | "duplicate" | "change";
+
+export default function CompareModal({ setIsOpen, productId, productName, compareType }: ModalProps) {
+  const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
+  const [productAName, setProductAName] = useState("");
+  const [productBName, setProductBName] = useState("");
+  const [isSelectedA, setIsSelectedA] = useState(false);
+  const [isSelectedB, setIsSelectedB] = useState(false);
+  const [isChanged, setIsChanged] = useState(false);
+  const [text, setText] = useState("");
+
+  const handleSelectItemA = () => {
+    setIsSelectedA(true);
+    setIsSelectedB(false);
+  };
+  const handleSelectItemB = () => {
+    setIsSelectedA(false);
+    setIsSelectedB(true);
+  };
+
+  const handleChange = () => {
+    if (isSelectedA) {
+      localStorage.setItem("productBId", String(productId));
+      localStorage.setItem("productBName", productName);
+    } else {
+      localStorage.setItem("productAId", String(productId));
+      localStorage.setItem("productAName", productName);
+    }
+    setIsChanged(true);
+  };
+
+  const stopEventBubbing = (e: React.MouseEvent) => {
+    e.stopPropagation();
+  };
+
+  useEffect(() => {
+    setPortalRoot(document.body);
+    if (localStorage.getItem("productAName")) {
+      setProductAName(localStorage.getItem("productAName") as string);
+    }
+    if (localStorage.getItem("productBName")) {
+      setProductBName(localStorage.getItem("productBName") as string);
+    }
+
+    switch (compareType) {
+      case "first":
+      case "second":
+        setText(`${productName} 항목이 등록되었습니다.`);
+        break;
+
+      case "duplicate":
+        setText("이미 등록되었습니다.");
+        break;
+
+      case "change":
+        setText(`지금 보신 ${productName}`);
+        break;
+    }
+  }, []);
+
+  const handleCloseButton = () => setIsOpen(false);
+
+  return (
+    compareType &&
+    portalRoot &&
+    createPortal(
+      <S.Background onClick={handleCloseButton}>
+        <S.Container $isSmall={false} onClick={stopEventBubbing}>
+          <S.Header>
+            <S.Title>
+              {!isChanged ? (
+                <>
+                  {text}
+                  {compareType === "change" && (
+                    <>
+                      <br />
+                      {"어떤 상품과 비교할까요?"}
+                    </>
+                  )}
+                </>
+              ) : (
+                <>
+                  {"비교 상품이 교체되었습니다."}
+                  <br />
+                  {"바로 확인해 보시겠어요?"}
+                </>
+              )}
+            </S.Title>
+            <S.CloseButton onClick={handleCloseButton}>
+              <Image fill src="/icons/closeSvgr.svg" alt="" />
+            </S.CloseButton>
+          </S.Header>
+          {(compareType === "first" || compareType === "duplicate") && (
+            <StyledPrimaryButton onClick={handleCloseButton}>확인</StyledPrimaryButton>
+          )}
+          {compareType === "second" && (
+            <Link href={PAGE_ROUTES.COMPARE}>
+              <StyledPrimaryButton onClick={handleCloseButton}>비교하기</StyledPrimaryButton>
+            </Link>
+          )}
+          {compareType === "change" && !isChanged && (
+            <>
+              <StyledProductButtonContainer>
+                <StyledProductButton onClick={handleSelectItemA} $isSelected={isSelectedA}>
+                  {productAName}
+                </StyledProductButton>
+                <StyledProductButton onClick={handleSelectItemB} $isSelected={isSelectedB}>
+                  {productBName}
+                </StyledProductButton>
+              </StyledProductButtonContainer>
+              <StyledPrimaryButton disabled={!isSelectedA && !isSelectedB} onClick={handleChange}>
+                교체하기
+              </StyledPrimaryButton>
+            </>
+          )}
+          {isChanged && (
+            <Link href={PAGE_ROUTES.COMPARE}>
+              <StyledPrimaryButton>바로가기</StyledPrimaryButton>
+            </Link>
+          )}
+        </S.Container>
+      </S.Background>,
+      document.body,
+    )
+  );
+}
+
+const StyledPrimaryButton = styled.button`
+  margin-top: 30px;
+  display: flex;
+  width: 100%;
+  height: 50px;
+  padding: 24px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+
+  border-radius: 8px;
+  background: var(--color-main-gradation, linear-gradient(91deg, #5097fa 0%, #5363ff 100%));
+
+  color: var(--color-white-f1, #f1f1f5);
+  text-align: center;
+  font-family: Pretendard;
+  font-style: normal;
+  ${fontStyle({ w: 600, s: 16, l: 18 })};
+
+  &:disabled {
+    background: var(--color-black-35, #353542);
+    color: var(--color-gray-6e, #6e6e82);
+  }
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.tablet}) {
+    margin-top: 40px;
+    height: 55px;
+    flex-shrink: 1;
+  }
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.desktop}) {
+    height: 65px;
+    ${fontStyle({ w: 600, s: 18, l: 20 })};
+  }
+`;
+
+const StyledProductButtonContainer = styled.div`
+  margin-top: 30px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.tablet}) {
+    margin-top: 40px;
+    gap: 15px;
+  }
+
+  @media (min-width: ${({ theme }) => theme.deviceSizes.desktop}) {
+    gap: 20px;
+  }
+`;
+
+const StyledProductButton = styled(StyledPrimaryButton)<StyledProductButtonProps>`
+  margin-top: 0;
+  border: 1px solid var(--color-black-35, #353542);
+  background: unset;
+  color: var(--color-gray-6e, #6e6e82);
+
+  ${({ $isSelected }) =>
+    $isSelected &&
+    `border: 1px solid var(--color-pink-ff, #ff2f9f);
+  background: unset;
+  color: var(--color-pink-ff, #ff2f9f);`}
+`;
+
+type StyledProductButtonProps = {
+  $isSelected: boolean;
+};

--- a/src/components/product/ProductDetail/index.tsx
+++ b/src/components/product/ProductDetail/index.tsx
@@ -4,6 +4,8 @@ import { StyledPrimaryButton, StyledProductButton } from "../../common/button/St
 import ProductText from "./ProductText";
 import { ProductDetailResponseType } from "@/src/apis/product/schema";
 import { getToken } from "@/src/apis/auth";
+import { useEffect, useState } from "react";
+import CompareModal from "../CompareModal/CompareModal";
 
 type ProductDetailProps = {
   productDetail: ProductDetailResponseType | {};
@@ -13,9 +15,33 @@ type ProductDetailProps = {
   editToggle: () => void;
 };
 
+type CompareModalType = "first" | "second" | "duplicate" | "change";
+
 function ProductDetail({ productDetail, userId, reviewToggle, loginToggle, editToggle }: ProductDetailProps) {
   const { id, name, image, description, category, isFavorite, writerId } = productDetail as ProductDetailResponseType;
   const createdByMe = writerId === userId;
+  const [isCompareModalOpen, setIsCompareModalOpen] = useState(false);
+  const [compareType, setCompareType] = useState<CompareModalType | null>(null);
+
+  const handleCompareButton = () => {
+    const productAId = localStorage.getItem("productAId");
+    const productBId = localStorage.getItem("productBId");
+
+    if (String(id) === productAId || String(id) === productBId) {
+      setCompareType("duplicate");
+    } else if (!productAId) {
+      setCompareType("first");
+      localStorage.setItem("productAId", String(id));
+      localStorage.setItem("productAName", name);
+    } else if (!productBId) {
+      setCompareType("second");
+      localStorage.setItem("productBId", String(id));
+      localStorage.setItem("productBName", name);
+    } else {
+      setCompareType("change");
+    }
+    setIsCompareModalOpen(true);
+  };
 
   const handleReviewClick = async () => {
     const token = await getToken();
@@ -52,7 +78,7 @@ function ProductDetail({ productDetail, userId, reviewToggle, loginToggle, editT
         />
         <S.ButtonContainer>
           <StyledPrimaryButton onClick={handleReviewClick}>리뷰 작성하기</StyledPrimaryButton>
-          <StyledProductButton $createdByMe={createdByMe} $buttonType="compare">
+          <StyledProductButton onClick={handleCompareButton} $createdByMe={createdByMe} $buttonType="compare">
             비교하기
           </StyledProductButton>
           {createdByMe && (
@@ -62,6 +88,14 @@ function ProductDetail({ productDetail, userId, reviewToggle, loginToggle, editT
           )}
         </S.ButtonContainer>
       </S.ProductTextWithButtons>
+      {isCompareModalOpen && (
+        <CompareModal
+          compareType={compareType as CompareModalType}
+          productId={id}
+          productName={name}
+          setIsOpen={setIsCompareModalOpen}
+        />
+      )}
     </S.Container>
   );
 }


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #159 
- 상품페이지 비교하기 버튼 기능 구현

## 스크린샷, 녹화

스크린샷은 기본, 녹화는 자유
- 첫번째 비교 상품 등록
![제품A](https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/78d5b2f3-633e-405e-a86b-faf4a28ab38b)

- 두번째 비교 상품 등록
![항목B](https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/7326399d-a436-4d9e-9e79-3c18cc4351cb)

- 중복 체크
![중복확인](https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/5e458cee-cf97-4f21-89c1-3494dfcd3915)

- 비교 상품 바꾸기
![비교교체](https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/f824134e-c466-4939-9eb1-18348f0ebd58)


## 구체적인 구현 설명
- 비교하기 버튼을 클릭하여 비교하기 기능을 사용할 수 있습니다.
    - 비교하고자 하는 상품이 없었을 경우, 비교하고자 하는 상품으로 추가되었다는 메세지를 확인할 수 있습니다.
    - 비교하고자 하는 상품이 하나 있었을 경우, 상품을 비교할 수 있다는 메세지와 함께 바로 확인하러갈지 고를 수 있습니다. 바로 확인하러 갈 경우 비교하기 화면`/compare` 으로 이동합니다.
    - 비교하고자 하는 상품이 두 개 있었을 경우, 비교 상품 교체 모달이 나타납니다.

### 비교 상품 교체 모달

- 기존에 비교 등록된 2개의 상품을 확인할 수 있습니다.
- 새로 비교 등록하려는 상품의 이름을 확인할 수 있습니다.
- 모달을 그냥 닫을 경우 비교 상품은 변경되지 않습니다.
- 기존에 등록된 2개 상품 중 하나를 선택해, 새 상품과 비교 등록할 수 있습니다.
- 상품을 교체했을 경우 비교 상품이 변경되었다는 메세지와 함께 바로 확인하러갈지 고를 수 있습니다. 바로 확인하러 갈 경우 비교하기 화면`/compare` 으로 이동합니다.

## 공유사항 (막히는 부분, 고민되는 부분)

- localStorage 에 productAId, productAName, productBId, productBName 에 접근해서 사용할 수 있습니다. 
