### PR TITLE
feat:비교하기 버튼 별점, 리뷰, 찜 데이터 localStorage 저장

### DIFF
--- a/pages/products/[productId]/index.tsx
+++ b/pages/products/[productId]/index.tsx
@@ -56,6 +56,9 @@ export default function Product() {
       <ProductDetail
         productDetail={productDetail}
         userId={userId}
+        ratingCount={ratingCount}
+        favoriteCount={favoriteCount}
+        reviewCount={reviewCount}
         reviewToggle={reviewToggle}
         loginToggle={loginToggle}
         editToggle={editToggle}

--- a/src/components/product/CompareModal/CompareModal.tsx
+++ b/src/components/product/CompareModal/CompareModal.tsx
@@ -12,11 +12,22 @@ interface ModalProps {
   productName: string;
   productId: number;
   compareType: CompareModalType;
+  ratingCount: number;
+  favoriteCount: number;
+  reviewCount: number;
 }
 
 type CompareModalType = "first" | "second" | "duplicate" | "change";
 
-export default function CompareModal({ setIsOpen, productId, productName, compareType }: ModalProps) {
+export default function CompareModal({
+  setIsOpen,
+  productId,
+  productName,
+  compareType,
+  ratingCount,
+  favoriteCount,
+  reviewCount,
+}: ModalProps) {
   const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
   const [productAName, setProductAName] = useState("");
   const [productBName, setProductBName] = useState("");
@@ -38,9 +49,15 @@ export default function CompareModal({ setIsOpen, productId, productName, compar
     if (isSelectedA) {
       localStorage.setItem("productBId", String(productId));
       localStorage.setItem("productBName", productName);
+      localStorage.setItem("productBRating", String(ratingCount));
+      localStorage.setItem("productBfavorite", String(favoriteCount));
+      localStorage.setItem("productBReview", String(reviewCount));
     } else {
       localStorage.setItem("productAId", String(productId));
       localStorage.setItem("productAName", productName);
+      localStorage.setItem("productARating", String(ratingCount));
+      localStorage.setItem("productAfavorite", String(favoriteCount));
+      localStorage.setItem("productAReview", String(reviewCount));
     }
     setIsChanged(true);
   };

--- a/src/components/product/ProductDetail/index.tsx
+++ b/src/components/product/ProductDetail/index.tsx
@@ -13,11 +13,23 @@ type ProductDetailProps = {
   reviewToggle: () => void;
   loginToggle: () => void;
   editToggle: () => void;
+  ratingCount: number;
+  favoriteCount: number;
+  reviewCount: number;
 };
 
 type CompareModalType = "first" | "second" | "duplicate" | "change";
 
-function ProductDetail({ productDetail, userId, reviewToggle, loginToggle, editToggle }: ProductDetailProps) {
+function ProductDetail({
+  productDetail,
+  userId,
+  ratingCount,
+  favoriteCount,
+  reviewCount,
+  reviewToggle,
+  loginToggle,
+  editToggle,
+}: ProductDetailProps) {
   const { id, name, image, description, category, isFavorite, writerId } = productDetail as ProductDetailResponseType;
   const createdByMe = writerId === userId;
   const [isCompareModalOpen, setIsCompareModalOpen] = useState(false);
@@ -33,10 +45,16 @@ function ProductDetail({ productDetail, userId, reviewToggle, loginToggle, editT
       setCompareType("first");
       localStorage.setItem("productAId", String(id));
       localStorage.setItem("productAName", name);
+      localStorage.setItem("productARating", String(ratingCount));
+      localStorage.setItem("productAfavorite", String(favoriteCount));
+      localStorage.setItem("productAReview", String(reviewCount));
     } else if (!productBId) {
       setCompareType("second");
       localStorage.setItem("productBId", String(id));
       localStorage.setItem("productBName", name);
+      localStorage.setItem("productBRating", String(ratingCount));
+      localStorage.setItem("productBfavorite", String(favoriteCount));
+      localStorage.setItem("productBReview", String(reviewCount));
     } else {
       setCompareType("change");
     }
@@ -94,6 +112,9 @@ function ProductDetail({ productDetail, userId, reviewToggle, loginToggle, editT
           compareType={compareType as CompareModalType}
           productId={id}
           productName={name}
+          ratingCount={ratingCount}
+          favoriteCount={favoriteCount}
+          reviewCount={reviewCount}
           setIsOpen={setIsCompareModalOpen}
         />
       )}


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #170 
- 비교하기 버튼 별점, 리뷰, 찜 데이터 localStorage 저장

## 스크린샷, 녹화
- 생략

## 구체적인 구현 설명
- localStorage 데이터 추가 저장
- productARating, productAfavorite, productAReview 
- productBRating, productBfavorite, productBReview 

## 공유사항 (막히는 부분, 고민되는 부분)
- localStorage 데이터는 문자열이므로 필요에 따라 변환해서 사용하시면 됩니다!
