### PR TITLE
Design: FormSelect의 x 버튼 숨기고, indicator 디자인 변경

### DIFF
--- a/src/components/common/button/Styled/StyledSelectDropdown.tsx
+++ b/src/components/common/button/Styled/StyledSelectDropdown.tsx
@@ -78,6 +78,7 @@ export const StyledSelectDropdown = styled(Select).attrs({ classNamePrefix: "rea
 
   .react-select__indicators {
     svg {
+      display: none;
       height: 2rem;
       width: 2rem;
     }

--- a/src/components/common/input/FormSelect/index.tsx
+++ b/src/components/common/input/FormSelect/index.tsx
@@ -1,6 +1,7 @@
 import { Controller, useFormContext } from "react-hook-form";
 import ReactSelect from "react-select";
 import { StyledSelectDropdown } from "../../button/Styled/StyledSelectDropdown";
+import Image from "next/image";
 
 interface FormSelectProps {
   options: { value: number; label: string }[];
@@ -25,6 +26,9 @@ function FormSelect({ options, name, placeholder, setSelectedProductId }: FormSe
             if (selectedOption && setSelectedProductId) {
               setSelectedProductId((selectedOption as { value: number; label: string }).value);
             }
+          }}
+          components={{
+            DropdownIndicator: () => <Image width={24} height={24} src="/icons/select_arrow.svg" alt="화살표" />,
           }}
         />
       )}


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #176 
- FormSelect의 x 버튼 숨기고, indicator 디자인 변경

## 스크린샷, 녹화

스크린샷은 기본, 녹화는 자유
_변경사항을 테스트하는 방법, 테스트에 사용된 기기 및 브라우저, UI 변경에 대한 관련 이미지 등에 대한 지침을 이곳에 기재해 주세요._

수정 전
<img width="615" alt="스크린샷 2024-03-26 오후 1 24 24" src="https://github.com/5-1-Mogazoa/Mogazoa/assets/131663155/5440b463-8d7e-4e70-a5ae-94ab5f13a428">

수정 후
<img width="613" alt="스크린샷 2024-03-26 오후 1 23 41" src="https://github.com/5-1-Mogazoa/Mogazoa/assets/131663155/b6fdd6aa-8784-4d13-8337-626c9c33f55a">



## 구체적인 구현 설명

- 구체적인 동작 방법 설명

## 공유사항 (막히는 부분, 고민되는 부분)

-
