### PR TITLE
Chore: 리뷰목록 정렬기준 변경시에도 스크롤 위치 유지하기

### DIFF
--- a/src/components/product/ReviewList/index.tsx
+++ b/src/components/product/ReviewList/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import * as S from "./styled";
 import ReviewItem from "../ReviewItem";
 import SortDropdown from "../../common/button/SortDropdown";
@@ -20,6 +20,9 @@ type ReviewListProps = {
 
 function ReviewList({ productId, order, setOrder, loginToggle }: ReviewListProps) {
   const [ref, inView] = useInView();
+  const reviewListRef = useRef<HTMLDivElement>(null);
+
+  const [listHeight, setListHeight] = useState(0);
 
   const {
     data: reviewData,
@@ -44,24 +47,39 @@ function ReviewList({ productId, order, setOrder, loginToggle }: ReviewListProps
     }
   }, [inView, fetchNextPage]);
 
+  useLayoutEffect(() => {
+    // 렌더링 후 layout, paint 전에 저장된 scroll 위치로 이동
+    if (typeof window !== "undefined") {
+      window.scroll(0, sessionStorage.y);
+    }
+  }, []);
+
   // 리뷰목록의 정렬기준 버튼클릭 이벤트
   const handleOrderButtonClick = (orderItem: OrderType) => {
     setOrder(orderItem);
+
+    // 현재 리뷰 목록 높이를 저장
+    if (reviewListRef.current) {
+      const height = reviewListRef.current.clientHeight;
+      setListHeight(height);
+    }
   };
 
-  if (!reviewData) return null;
+  const rememberScroll = () => {
+    sessionStorage.setItem("y", String(window.scrollY));
+  };
 
-  const reviewList = reviewData?.pages[0].list;
+  const reviewList = reviewData?.pages[0].list || [];
   const noList = reviewList.length === 0;
 
   return (
-    <S.Container>
+    <S.Container onClick={rememberScroll}>
       <S.TitleWithOrer>
         상품 리뷰
         <SortDropdown type="products" selectedItem={order} handleOrderButtonClick={handleOrderButtonClick} />
       </S.TitleWithOrer>
       {noList && <S.NoList>첫번째 상품리뷰를 등록해보세요!</S.NoList>}
-      <S.List>
+      <S.List ref={reviewListRef} $listHeight={listHeight}>
         {reviewData?.pages.map((page) => (
           <React.Fragment key={page.nextCursor}>
             {page.list.map((review) => (

--- a/src/components/product/ReviewList/styled.tsx
+++ b/src/components/product/ReviewList/styled.tsx
@@ -17,7 +17,13 @@ export const TitleWithOrer = styled.div`
   align-items: center;
 `;
 
-export const List = styled(S.List)`
+interface ListProps {
+  $listHeight: number | undefined;
+}
+
+export const List = styled(S.List)<ListProps>`
+  min-height: ${({ $listHeight }) => ($listHeight ? `${$listHeight}px` : 0)};
+
   @media (min-width: ${({ theme }) => theme.deviceSizes.tablet}) {
     flex-direction: column;
   }


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #207 
- products 페이지에서 리뷰목록의 정렬기준 변경해도 페이지의 스크롤 위치 유지하기 
   (변경 전에는 정렬기준 바꾸면 다시 페이지 상단으로 이동했습니다!)

## 스크린샷, 녹화

스크린샷은 기본, 녹화는 자유
_변경사항을 테스트하는 방법, 테스트에 사용된 기기 및 브라우저, UI 변경에 대한 관련 이미지 등에 대한 지침을 이곳에 기재해 주세요._

## 구체적인 구현 설명

- 구체적인 동작 방법 설명

## 공유사항 (막히는 부분, 고민되는 부분)

-
