### PR TITLE
Chore: 상품 편집 요청 실패시 "이미 등록된 상품명이에요" 모달팝업 보여주기

### DIFF
--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -10,11 +10,20 @@ import { FieldValues, useFormContext } from "react-hook-form";
 interface ModalProps {
   title: string;
   subTitle?: string;
-  modalType: "follow" | "compare" | "compare_comfirm" | "review" | "edit" | "profile" | "add" | "login" | "delete";
+  modalType:
+    | "follow"
+    | "compare"
+    | "compare_comfirm"
+    | "review"
+    | "edit"
+    | "profile"
+    | "add"
+    | "login"
+    | "delete"
+    | "edit_error_name";
   category?: CategoryType | undefined;
   isFormData?: boolean;
-  // callback?: (data: FieldValues) => Promise<T>;
-  callback?: any;
+  callback?: ((data: FieldValues) => boolean) | ((data: FieldValues) => void);
   onClose: () => void;
   children?: ReactNode;
 }
@@ -26,7 +35,11 @@ function Modal({ title, subTitle, modalType, category, isFormData, callback, onC
 
   const isValid = formContext && formContext.formState.isValid;
   const isReview = modalType === "review";
-  const isSmall = modalType === "compare_comfirm" || modalType === "login" || modalType === "delete";
+  const isSmall =
+    modalType === "compare_comfirm" ||
+    modalType === "login" ||
+    modalType === "delete" ||
+    modalType === "edit_error_name";
   const isConfirmButton = isSmall || modalType === "compare";
   const isFollow = modalType === "follow";
 
@@ -37,8 +50,9 @@ function Modal({ title, subTitle, modalType, category, isFormData, callback, onC
   const handleButtonClick = async (data: FieldValues) => {
     if (typeof callback === "function") {
       try {
-        await callback(data);
-        onClose();
+        const isSuccess = await callback(data);
+
+        if (isSuccess) onClose();
       } catch (error) {
         throw error;
       }

--- a/src/constant/MODAL_BUTTON.ts
+++ b/src/constant/MODAL_BUTTON.ts
@@ -7,6 +7,7 @@ const MODAL_BUTTON: Record<string, string> = {
   add: "추가하기",
   login: "로그인하기",
   delete: "삭제하기",
+  edit_error_name: "상품명 바꾸기",
 };
 
 export default MODAL_BUTTON;


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #209 
- /products 페이지에서 상품 편집 요청 실패시 "이미 등록된 상품명이에요"라는 모달팝업 띄우기

## 스크린샷, 녹화

스크린샷은 기본, 녹화는 자유
_변경사항을 테스트하는 방법, 테스트에 사용된 기기 및 브라우저, UI 변경에 대한 관련 이미지 등에 대한 지침을 이곳에 기재해 주세요._

https://github.com/5-1-Mogazoa/Mogazoa/assets/131663155/99627b63-2cb6-4882-ad3a-6e5f9013374a





## 구체적인 구현 설명

- 구체적인 동작 방법 설명

## 공유사항 (막히는 부분, 고민되는 부분)

-
