### PR TITLE
fix: 유저 데이터 수정 시, 바로 적용

### DIFF
--- a/src/components/profiles/MyPageProfileButtons.tsx
+++ b/src/components/profiles/MyPageProfileButtons.tsx
@@ -4,7 +4,11 @@ import { resetToken } from "@/src/apis/auth";
 import ProfileEditModal from "./ProfileEditModal";
 import { useState } from "react";
 
-export default function MyPageProfileButtons() {
+type MyPageProfileButtons = {
+  handleIsDataUpdated: () => void;
+};
+
+export default function MyPageProfileButtons({ handleIsDataUpdated }: MyPageProfileButtons) {
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
 
@@ -20,7 +24,7 @@ export default function MyPageProfileButtons() {
   return (
     <StyledButtonsContainer>
       <StyledProfileEditButton onClick={handleProfileEditButton}>프로필 편집</StyledProfileEditButton>
-      {isOpen && <ProfileEditModal setIsOpen={setIsOpen} />}
+      {isOpen && <ProfileEditModal handleIsDataUpdated={handleIsDataUpdated} setIsOpen={setIsOpen} />}
       <StyledLogOutButton onClick={handleLogOutButton}>로그아웃</StyledLogOutButton>
     </StyledButtonsContainer>
   );

--- a/src/components/profiles/ProfileEditModal.tsx
+++ b/src/components/profiles/ProfileEditModal.tsx
@@ -24,10 +24,11 @@ import { postImage } from "@/src/apis/image";
 
 interface ModalProps {
   setIsOpen: (value: boolean) => void;
+  handleIsDataUpdated: () => void;
 }
 
 // hasOptionsbutton 대신 modalType으로 review는 헤더부분 다르게 함
-export default function ProfileEditModal({ setIsOpen }: ModalProps) {
+export default function ProfileEditModal({ setIsOpen, handleIsDataUpdated }: ModalProps) {
   const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
 
   const { data: myData } = useQuery<UserPatchDataType>({
@@ -74,6 +75,7 @@ export default function ProfileEditModal({ setIsOpen }: ModalProps) {
     }
     try {
       await postMutation.mutateAsync(data);
+      handleIsDataUpdated();
     } catch (error: any) {
       //TODO: error 타입지정
       console.error(error);

--- a/src/components/profiles/UserProfile.tsx
+++ b/src/components/profiles/UserProfile.tsx
@@ -194,11 +194,18 @@ export default function Userprofile({ isMe, userId }: Props) {
   const [dataType, setDataType] = useState<"REVIEWED" | "CREATED" | "FAVORITE">("REVIEWED");
   const [isFollowingModalOpen, setIsFollowingModalOpen] = useState(false);
   const [isFollowerModalOpen, setIsFollowerModalOpen] = useState(false);
+  const [isDataUpdated, setIsDataUpdated] = useState(false);
+
+  const handleIsDataUpdated = () => setIsDataUpdated(!isDataUpdated);
 
   const { data: USERDATA } = useQuery({
-    queryKey: ["USERDATA", userId],
+    queryKey: ["USERDATA", userId, isDataUpdated],
     queryFn: () => getUserData(userId),
   });
+
+  useEffect(() => {
+    handleIsDataUpdated();
+  }, [USERDATA]);
 
   const { data: FOLLOWEES } = useQuery({
     queryKey: [QUERY_KEY.FOLLOWEES, userId],
@@ -276,7 +283,11 @@ export default function Userprofile({ isMe, userId }: Props) {
               </div>
             </div>
           </StyledFollowInfo>
-          {isMe ? <MyPageProfileButtons /> : <FollowButton isFollowingData={USERDATA?.isFollowing} userId={userId} />}
+          {isMe ? (
+            <MyPageProfileButtons handleIsDataUpdated={handleIsDataUpdated} />
+          ) : (
+            <FollowButton isFollowingData={USERDATA?.isFollowing} userId={userId} />
+          )}
         </StyledProfileBox>
 
         <StyledPageRight>


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #214 
- 유저데이터 편집 후 바로 적용

## 스크린샷, 녹화
![데이터변경](https://github.com/5-1-Mogazoa/Mogazoa/assets/144401634/17a9ce81-4127-4ab5-8dc5-fb1f24bc93bc)


## 구체적인 구현 설명

- 데이터 편집 후 변경사항 바로 적용

## 공유사항 (막히는 부분, 고민되는 부분)

-
