### PR TITLE
Fix: 리뷰 생성, 편집 모달 안 닫히는 오류 수정

### DIFF
--- a/src/components/product/ModalEditReview/index.tsx
+++ b/src/components/product/ModalEditReview/index.tsx
@@ -82,7 +82,12 @@ function ModalEditReview({ name, category, order, review, onClose }: ModalEditRe
       }
     }
 
-    patchReviewMutation.mutate(formData);
+    try {
+      await patchReviewMutation.mutate(formData);
+      return true;
+    } catch {
+      return false;
+    }
   };
 
   return (

--- a/src/components/product/ModalReview/index.tsx
+++ b/src/components/product/ModalReview/index.tsx
@@ -61,7 +61,13 @@ function ModalReview({ productId, name, category, order, onClose }: ModalReviewP
         console.error("이미지 업로드를 실패했어요.");
       }
     }
-    postReviewMutation.mutate(formData);
+
+    try {
+      await postReviewMutation.mutateAsync(formData);
+      return true;
+    } catch {
+      return false;
+    }
   };
 
   return (


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이슈 및 설명

- issue #216 
- 이전에 Modal에 boolean값에 따라 onClose()를 실행하도록 수정해서 발생한 리뷰 생성/편집 모달이 안닫히는 문제 해결


## 스크린샷, 녹화

스크린샷은 기본, 녹화는 자유
_변경사항을 테스트하는 방법, 테스트에 사용된 기기 및 브라우저, UI 변경에 대한 관련 이미지 등에 대한 지침을 이곳에 기재해 주세요._

![Apr-02-2024 12-45-55](https://github.com/5-1-Mogazoa/Mogazoa/assets/131663155/5ec8c7fa-a5a1-4d8d-a721-6c6926ba4d52)




## 구체적인 구현 설명

- 구체적인 동작 방법 설명

## 공유사항 (막히는 부분, 고민되는 부분)

-
